### PR TITLE
Add batch_size_multiplier to scale sgd minibatch sizes for agent and planner

### DIFF
--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -93,7 +93,9 @@ def choose_policy_optimizer(workers, config):
         train_batch_size=config["train_batch_size"],
         standardize_fields=["advantages"],
         shuffle_sequences=config["shuffle_sequences"],
-        batch_size_multiplier=config["batch_size_multiplier"])
+        batch_size_multiplier_agent=config["batch_size_multiplier_agent"],
+        batch_size_multiplier_planner=config["batch_size_multiplier_planner"]
+    )
 
 
 def update_kl(trainer, fetches):

--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -92,7 +92,8 @@ def choose_policy_optimizer(workers, config):
         num_envs_per_worker=config["num_envs_per_worker"],
         train_batch_size=config["train_batch_size"],
         standardize_fields=["advantages"],
-        shuffle_sequences=config["shuffle_sequences"])
+        shuffle_sequences=config["shuffle_sequences"],
+        batch_size_multiplier=config["batch_size_multiplier"])
 
 
 def update_kl(trainer, fetches):

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -285,7 +285,7 @@ COMMON_CONFIG = {
     # GPU-intensive video game), or model inference is unusually expensive.
     "num_gpus_per_worker": 0,
     # A multiplication factor used to scale the batch size in the optimizer.
-    # This is provided for agents and the planner separately so that each entity could
+    # This is provided for the agents and the planner separately so that each entity can
     # have it's own sgd minibatch size. Larger is this number, smaller is the number of
     # batches used for gradient descent
     "batch_size_multiplier_agent": 1,

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -390,7 +390,7 @@ class Trainer(Trainable):
         logdir (str): Directory in which training outputs should be placed.
     """
     # Whether to allow unknown top-level config keys.
-    _allow_unknown_configs = False
+    _allow_unknown_configs = True
 
     # List of top-level keys with value=dict, for which new sub-keys are
     # allowed to be added to the value dict.

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -284,9 +284,12 @@ COMMON_CONFIG = {
     # usually needed only if your env itself requires a GPU (i.e., it is a
     # GPU-intensive video game), or model inference is unusually expensive.
     "num_gpus_per_worker": 0,
-    # Batch Size Multiplier - multiplies the effective batch size in the optimizer.
-    # Larger is this number, fewer is the number of batches used for gradient descent
-    "batch_size_multiplier": 1,
+    # A multiplication factor used to scale the batch size in the optimizer.
+    # This is provided for agents and the planner separately so that each entity could
+    # have it's own sgd minibatch size. Larger is this number, smaller is the number of
+    # batches used for gradient descent
+    "batch_size_multiplier_agent": 1,
+    "batch_size_multiplier_planner": 1,
     # Any custom Ray resources to allocate per worker.
     "custom_resources_per_worker": {},
     # Number of CPUs to allocate for the trainer. Note: this only takes effect

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -284,6 +284,9 @@ COMMON_CONFIG = {
     # usually needed only if your env itself requires a GPU (i.e., it is a
     # GPU-intensive video game), or model inference is unusually expensive.
     "num_gpus_per_worker": 0,
+    # Batch Size Multiplier - multiplies the effective batch size in the optimizer.
+    # Larger is this number, fewer is the number of batches used for gradient descent
+    "batch_size_multiplier": 1,
     # Any custom Ray resources to allocate per worker.
     "custom_resources_per_worker": {},
     # Number of CPUs to allocate for the trainer. Note: this only takes effect
@@ -390,7 +393,7 @@ class Trainer(Trainable):
         logdir (str): Directory in which training outputs should be placed.
     """
     # Whether to allow unknown top-level config keys.
-    _allow_unknown_configs = True
+    _allow_unknown_configs = False
 
     # List of top-level keys with value=dict, for which new sub-keys are
     # allowed to be added to the value dict.

--- a/rllib/optimizers/multi_gpu_optimizer.py
+++ b/rllib/optimizers/multi_gpu_optimizer.py
@@ -194,11 +194,10 @@ class LocalMultiGPUOptimizer(PolicyOptimizer):
                 optimizer = self.optimizers[policy_id]
                 num_batches = max(
                     1,
-                    int(tuples_per_device) // int(self.per_device_batch_size))
+                    int(tuples_per_device) // (int(self.per_device_batch_size) * self.batch_size_multiplier))  # SS**
                 logger.debug("== sgd epochs for {} ==".format(policy_id))
                 for i in range(self.num_sgd_iter):
                     iter_extra_fetches = defaultdict(list)
-                    num_batches = max(1, num_batches // self.batch_size_multiplier)  # SS**
                     permutation = np.random.permutation(num_batches)
                     for batch_index in range(num_batches):
                         batch_fetches = optimizer.optimize(

--- a/rllib/optimizers/multi_gpu_optimizer.py
+++ b/rllib/optimizers/multi_gpu_optimizer.py
@@ -198,7 +198,7 @@ class LocalMultiGPUOptimizer(PolicyOptimizer):
                 logger.debug("== sgd epochs for {} ==".format(policy_id))
                 for i in range(self.num_sgd_iter):
                     iter_extra_fetches = defaultdict(list)
-                    num_batches /= self.batch_size_multiplier  # SS**
+                    num_batches = max(1, num_batches // self.batch_size_multiplier)  # SS**
                     permutation = np.random.permutation(num_batches)
                     for batch_index in range(num_batches):
                         batch_fetches = optimizer.optimize(


### PR DESCRIPTION
rllib currently uses the same sgd_minibatch_size for both agents and planner. As the number of agents scale up, there's a lot more agent trajectories collected which means more sgd updates (given the fixed sgd_minibatch_size) which slows down training. Added two batch_size_multiplier factors for the agents/planner to have separate agents' and planner's sgd_minibatch_sizes.

NOTE: only works with PPO and LocalMultiGPUOptimizer